### PR TITLE
fix: Added interactive inheritance

### DIFF
--- a/Sources/SnapshotSafeView/Core/ScreenshotInvincibleContainer.swift
+++ b/Sources/SnapshotSafeView/Core/ScreenshotInvincibleContainer.swift
@@ -40,6 +40,11 @@ final class ScreenshotInvincibleContainer: UITextField {
     public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         return container?.hitTest(point, with: event)
     }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        isUserInteractionEnabled = content.isUserInteractionEnabled
+    }
     
     // MARK: - Private methods
     
@@ -47,6 +52,7 @@ final class ScreenshotInvincibleContainer: UITextField {
         appendContent(to: container)
 
         backgroundColor = .clear
+        isUserInteractionEnabled = content.isUserInteractionEnabled
     }
     
     private func activateLayoutConstraintsOfContent(to view: UIView) {


### PR DESCRIPTION
## **What was done?**

- Added [interactive inheritance](https://github.com/Stampoo/SnapshotSafeView/commit/391674324a131c6d23b944137fca06e45454db99), because we can touch on `container` with non-interactive lements 

## **What to look for?**

1. Rup app
2. Try to interact with tableview with didSelectRowAt events
3. Try to interact with another non-interractable elements