### PR TITLE
Adding support for multiplatform(React-Native, Flutter)

### DIFF
--- a/SnapshotSafeView.podspec
+++ b/SnapshotSafeView.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+
+  s.name = "SnapshotSafeView"
+  s.version = "0.2.0"
+  s.summary = "Used for hide view from system screenshots and video recording."
+  s.description  = "Used for hide view from system screenshots and video recording."
+
+  s.homepage  = "https://github.com/Stampoo/SnapshotSafeView"
+  s.license  = { :type => "MIT", :file => "LICENSE" }
+  s.author  = { "Ilya Knyazkov" => "fivecoil@gmail.com" }
+  s.source = { :git => "https://github.com/surfstudio/ios-utils.git", :tag => "#{s.version}" }
+  s.ios.deployment_target = '12.0'
+  s.swift_version = '5.5'
+
+end

--- a/Sources/SnapshotSafeView/MultiplatformBridgeView/MultiplatformBridgeView.swift
+++ b/Sources/SnapshotSafeView/MultiplatformBridgeView/MultiplatformBridgeView.swift
@@ -1,0 +1,57 @@
+//
+//  MultiplatformBridgeView.swift
+//  
+//
+//  Created by Илья Князьков on 19.01.2023.
+//
+
+import UIKit
+
+open class MultiplatformBridgeView: UIView {
+
+    // MARK: - Private Properties
+
+    private let screenshotSafeContainer: ScreenshotInvincibleContainer
+    private var setupInitialStateIsPerformed: Bool = false
+
+    // MARK: - Initialization
+
+    public init() {
+        self.screenshotSafeContainer = ScreenshotInvincibleContainer(content: UIView())
+        super.init(frame: .zero)
+
+        configureScreenshotSafeContainer()
+    }
+
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UIView
+
+    override open func addSubview(_ view: UIView) {
+        guard setupInitialStateIsPerformed else {
+            return super.addSubview(view)
+        }
+        screenshotSafeContainer.content.addSubview(view)
+    }
+
+}
+
+// MARK: - Private Methods
+
+private extension MultiplatformBridgeView {
+
+    func configureScreenshotSafeContainer() {
+        screenshotSafeContainer.setupContanerAsHideContentInScreenshots()
+        addSubview(screenshotSafeContainer)
+        [
+            screenshotSafeContainer.topAnchor.constraint(equalTo: topAnchor),
+            screenshotSafeContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
+            screenshotSafeContainer.leftAnchor.constraint(equalTo: leftAnchor),
+            screenshotSafeContainer.rightAnchor.constraint(equalTo: rightAnchor)
+        ].forEach { $0.isActive = true }
+        setupInitialStateIsPerformed = true
+    }
+
+}


### PR DESCRIPTION
## **What was done?**

- [MultiplatformBridgeView](https://github.com/Stampoo/SnapshotSafeView/pull/19/commits/ff5fdfb27154e7b731b716bb9b3c457ab372116a) was created(Main unit for Multiplatform views)

## **What to look for?**

Now you can implement only for React-Native, without automation.

Bridge:
```swift
import UIKit
import SnapshotSafeView

final class ReactNativeBridgeSnapshotSafeView: MultiplatformBridgeView { }
```

Objc bridge:
```objc
#import <React/RCTViewManager.h>

@interface RCT_EXTERN_MODULE(RCTReactNativeBridgeSnapshotSafeViewManager, RCTViewManager)
@end
```

React-native fabric:
```swift
#if canImport(React)
import React

@objc (RCTReactNativeBridgeSnapshotSafeViewManager)
class ReactNativeBridgeSnapshotSafeViewManager: RCTViewManager {

  override static func requiresMainQueueSetup() -> Bool {
    return true
  }

  override func view() -> UIView! {
    let view = ReactNativeBridgeSnapshotSafeView()
    return view
  }

}
#endif
```
Example: 

<p>
<image src=https://user-images.githubusercontent.com/44356536/213511469-ac6b342b-56d2-4612-a6b8-575f945fcaf4.mov width=500>
</p>